### PR TITLE
Fix passing block case with no html_options

### DIFF
--- a/lib/action_view/encoded_mail_to/mail_to_with_encoding.rb
+++ b/lib/action_view/encoded_mail_to/mail_to_with_encoding.rb
@@ -47,7 +47,7 @@ module EncodedMailTo
         #            subject: "This is an example email"
         #   # => <a href="mailto:me@domain.com?cc=ccaddress@domain.com&subject=This%20is%20an%20example%20email">My email</a>
         def mail_to_with_encoding(email_address, name = nil, html_options = {}, &block)
-          html_options, name = name, nil if block_given? && html_options.blank?
+          html_options, name = name || {}, nil if block_given? && html_options.blank?
           html_options.stringify_keys!
           if %w[encode replace_at replace_dot].none?{ |option| html_options.has_key? option }
             mail_to_without_encoding email_address, name, html_options, &block

--- a/test/test_actionview-encoded_mail_to.rb
+++ b/test/test_actionview-encoded_mail_to.rb
@@ -29,6 +29,10 @@ class TestActionViewEncodedMailTo < MiniTest::Test
                  mail_to("nick@example.com", "Nick Reed", class: "admin")
   end
 
+  def test_mail_to_with_block
+    assert_equal(%{<a href="mailto:nick@example.com">Nick</a>}, mail_to("nick@example.com"){'Nick'})
+  end
+
   def test_mail_to_without_encoding
     assert_equal mail_to("nick@example.com", "Nick Reed"),
                  mail_to_without_encoding("nick@example.com", "Nick Reed")


### PR DESCRIPTION
Fixed a case where a block is passed with no options are given.