### PR TITLE
Reorder arguments if block given and no encoding needed

### DIFF
--- a/lib/action_view/encoded_mail_to/mail_to_with_encoding.rb
+++ b/lib/action_view/encoded_mail_to/mail_to_with_encoding.rb
@@ -48,7 +48,11 @@ module ActionView
         html_options, name = name || {}, nil if block_given? && html_options.blank?
         html_options.stringify_keys!
         if %w[encode replace_at replace_dot].none?{ |option| html_options.has_key? option }
-          super email_address, name, html_options, &block
+          if block_given?
+            super email_address, html_options, nil, &block
+          else
+            super email_address, name, html_options, &block
+          end
         else
           _mail_to_with_encoding email_address, name, html_options, &block
         end


### PR DESCRIPTION
If one tries to use the vanilla mail_to through the gem, the arguments will get messed up if used with a block. This is due to line 48 which is executed in the gem as well as in the super, messing up the order of arguments.
We effectively need to reverse line 48 if we want to call the super, otherwise the html_options will not be passed to the super. 
